### PR TITLE
Fix to create charge using non-default card

### DIFF
--- a/v1/charge.go
+++ b/v1/charge.go
@@ -26,6 +26,7 @@ type Charge struct {
 	CustomerID  string            // 顧客ID (CardかCustomerのどちらかは必須パラメータ)
 	Card        Card              // カードオブジェクト(cardかcustomerのどちらかは必須)
 	CardToken   string            // トークンID (CardかCustomerのどちらかは必須パラメータ)
+	CustomerCardID	string        // 顧客のカードID
 	Capture     bool              // 支払い処理を確定するかどうか (falseの場合、カードの認証と支払い額の確保のみ行う)
 	Description string            // 	概要
 	ExpireDays  interface{}       // デフォルトで7日となっており、1日~60日の間で設定が可能
@@ -33,6 +34,7 @@ type Charge struct {
 }
 
 // Create はトークンID、カードを保有している顧客ID、カードオブジェクトのいずれかのパラメーターを指定して支払いを作成します。
+// 顧客IDを使って支払いを作成する場合は CustomerCardID に顧客の保有するカードのIDを指定でき、省略された場合はデフォルトカードとして登録されているものが利用されます。
 // テスト用のキーでは、本番用の決済ネットワークへは接続されず、実際の請求が行われることもありません。 本番用のキーでは、決済ネットワークで処理が行われ、実際の請求が行われます。
 //
 // 支払いを確定せずに、カードの認証と支払い額のみ確保する場合は、 Capture に false を指定してください。 このとき ExpireDays を指定することで、認証の期間を定めることができます。 ExpireDays はデフォルトで7日となっており、1日~60日の間で設定が可能です。
@@ -76,8 +78,10 @@ func (c ChargeService) Create(amount int, charge Charge) (*ChargeResponse, error
 	qb.Add("currency", charge.Currency)
 	if charge.CustomerID != "" {
 		qb.Add("customer", charge.CustomerID)
-	}
-	if charge.CardToken != "" {
+		if charge.CustomerCardID != "" {
+			qb.Add("card", charge.CustomerCardID)
+		}
+	} else if charge.CardToken != "" {
 		qb.Add("card", charge.CardToken)
 	}
 	qb.AddCard(charge.Card)

--- a/v1/charge_test.go
+++ b/v1/charge_test.go
@@ -131,7 +131,7 @@ func TestParseChargeErrorResponseJSON(t *testing.T) {
 func TestChargeCreate(t *testing.T) {
 	mock, transport := NewMockClient(200, chargeResponseJSON)
 	service := New("api-key", mock)
-	plan, err := service.Charge.Create(1000, Charge{
+	charge, err := service.Charge.Create(1000, Charge{
 		Card: Card{
 			Number:   "4242424242424242",
 			ExpMonth: 2,
@@ -148,10 +148,32 @@ func TestChargeCreate(t *testing.T) {
 		t.Errorf("err should be nil, but %v", err)
 		return
 	}
-	if plan == nil {
-		t.Error("plan should not be nil")
-	} else if plan.Amount != 3500 {
-		t.Errorf("plan.Amount should be 500, but %d.", plan.Amount)
+	if charge == nil {
+		t.Error("charge should not be nil")
+	} else if charge.Amount != 3500 {
+		t.Errorf("charge.Amount should be 3500, but %d.", charge.Amount)
+	}
+}
+
+func TestChargeCreateByNonDefaultard(t *testing.T) {
+	mock, transport := NewMockClient(200, chargeResponseJSON)
+	service := New("api-key", mock)
+	charge, err := service.Charge.Create(1000, Charge{
+		CustomerID: "cus_xxxxxxxxx",
+		CustomerCardID: "car_xxxxxxxxx",
+	})
+
+	if transport.URL != "https://api.pay.jp/v1/charges" {
+		t.Errorf("URL is wrong: %s", transport.URL)
+	}
+
+	if err != nil {
+		t.Errorf("err should be nil, but %v", err)
+		return
+	}
+
+	if charge == nil {
+		t.Error("charge should not be nil")
 	}
 }
 


### PR DESCRIPTION
Fix for API change, create Charge by using non-default card.

- Add `CustomerCardID` at `Charge` struct
- `CustomerCardID` is use as `card` param for API, only when `CustomerID` is specified