### PR TITLE
Go言語サポートバージョンの更新 & fix lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ sudo: false
 language: go
 
 go:
-  - 1.6
-  - 1.7
-  - tip
+  - stable
+  - 1.11.x
+  - 1.10.x
+  - 1.9.x
 
-#install:
-#  - go get -u github.com/golang/lint/golint
+install:
+  - go get -u golang.org/x/lint/golint
 
 script:
-#  - golint ./...
+  - golint ./...
   - go test -v ./...

--- a/v1/account.go
+++ b/v1/account.go
@@ -16,7 +16,7 @@ func newAccountService(service *Service) *AccountService {
 	return &AccountService{service}
 }
 
-// Get はあなたのアカウント情報を取得します。
+// Retrieve account object. あなたのアカウント情報を取得します。
 func (t *AccountService) Retrieve() (*AccountResponse, error) {
 	request, err := http.NewRequest("GET", t.service.apiBase+"/accounts", nil)
 	if err != nil {

--- a/v1/charge.go
+++ b/v1/charge.go
@@ -105,7 +105,7 @@ func (c ChargeService) Create(amount int, charge Charge) (*ChargeResponse, error
 
 }
 
-// Get は生成された支払い情報を取得します。
+// Retrieve charge object. 支払い情報を取得します。
 func (c ChargeService) Retrieve(chargeID string) (*ChargeResponse, error) {
 	body, err := c.service.retrieve("/charges/" + chargeID)
 	if err != nil {

--- a/v1/client.go
+++ b/v1/client.go
@@ -91,7 +91,7 @@ func (s Service) delete(resourceURL string) error {
 
 func (s Service) queryList(resourcePath string, limit, offset, since, until int, callbacks ...func(*url.Values) bool) ([]byte, error) {
 	if limit < 0 || limit > 100 {
-		return nil, fmt.Errorf("List().Limit() should be between 1 and 100, but %d.", limit)
+		return nil, fmt.Errorf("method Limit() should be between 1 and 100, but %d", limit)
 	}
 
 	values := url.Values{}

--- a/v1/customer.go
+++ b/v1/customer.go
@@ -83,7 +83,7 @@ func (c CustomerService) Create(customer Customer) (*CustomerResponse, error) {
 	return parseCustomer(c.service, body, &CustomerResponse{})
 }
 
-// Get は生成した顧客情報を取得します。
+// Retrieve customer object. 顧客情報を取得します。
 func (c CustomerService) Retrieve(id string) (*CustomerResponse, error) {
 	body, err := c.service.retrieve("/customers/" + id)
 	if err != nil {

--- a/v1/event.go
+++ b/v1/event.go
@@ -69,7 +69,7 @@ func newEventService(service *Service) *EventService {
 	}
 }
 
-// Get メソッドは特定のイベント情報を取得します。
+// Retrieve event object. 特定のイベント情報を取得します。
 func (e EventService) Retrieve(id string) (*EventResponse, error) {
 	data, err := e.service.retrieve("/events/" + id)
 	if err != nil {
@@ -194,7 +194,7 @@ type EventResponse struct {
 // ChargeData は、イベントの種類がChargeEventの時にChargeResponse構造体を返します。
 func (e EventResponse) ChargeData() (*ChargeResponse, error) {
 	if e.ResultType != ChargeEvent {
-		return nil, errors.New("This event is not charge type.")
+		return nil, errors.New("this event is not charge type")
 	}
 	result := &ChargeResponse{}
 	json.Unmarshal(e.data, result)
@@ -204,7 +204,7 @@ func (e EventResponse) ChargeData() (*ChargeResponse, error) {
 // TokenData は、イベントの種類がTokenEventの時にTokenResponse構造体を返します。
 func (e EventResponse) TokenData() (*TokenResponse, error) {
 	if e.ResultType != TokenEvent {
-		return nil, errors.New("This event is not token type.")
+		return nil, errors.New("this event is not token type")
 	}
 	result := &TokenResponse{}
 	json.Unmarshal(e.data, result)
@@ -214,7 +214,7 @@ func (e EventResponse) TokenData() (*TokenResponse, error) {
 // CustomerData は、イベントの種類がCustomerEventの時にCustomerResponse構造体を返します。
 func (e EventResponse) CustomerData() (*CustomerResponse, error) {
 	if e.ResultType != CustomerEvent {
-		return nil, errors.New("This event is not customer type.")
+		return nil, errors.New("this event is not customer type")
 	}
 	result := &CustomerResponse{}
 	json.Unmarshal(e.data, result)
@@ -224,7 +224,7 @@ func (e EventResponse) CustomerData() (*CustomerResponse, error) {
 // CardData は、イベントの種類がCardEventの時にCardResponse構造体を返します。
 func (e EventResponse) CardData() (*CardResponse, error) {
 	if e.ResultType != CardEvent {
-		return nil, errors.New("This event is not card type.")
+		return nil, errors.New("this event is not card type")
 	}
 	result := &CardResponse{}
 	json.Unmarshal(e.data, result)
@@ -234,7 +234,7 @@ func (e EventResponse) CardData() (*CardResponse, error) {
 // PlanData は、イベントの種類がPlanEventの時にPlanResponse構造体を返します。
 func (e EventResponse) PlanData() (*PlanResponse, error) {
 	if e.ResultType != PlanEvent {
-		return nil, errors.New("This event is not plan type.")
+		return nil, errors.New("this event is not plan type")
 	}
 	result := &PlanResponse{}
 	json.Unmarshal(e.data, result)
@@ -244,7 +244,7 @@ func (e EventResponse) PlanData() (*PlanResponse, error) {
 // SubscriptionData は、イベントの種類がSubscriptionEventの時にSubscriptionResponse構造体を返します。
 func (e EventResponse) SubscriptionData() (*SubscriptionResponse, error) {
 	if e.ResultType != SubscriptionEvent {
-		return nil, errors.New("This event is not subscription type.")
+		return nil, errors.New("this event is not subscription type")
 	}
 	result := &SubscriptionResponse{}
 	json.Unmarshal(e.data, result)
@@ -254,7 +254,7 @@ func (e EventResponse) SubscriptionData() (*SubscriptionResponse, error) {
 // TransferData は、イベントの種類がTransferEventの時にTransferResponse構造体を返します。
 func (e EventResponse) TransferData() (*TransferResponse, error) {
 	if e.ResultType != TransferEvent {
-		return nil, errors.New("This event is not tranfer type.")
+		return nil, errors.New("this event is not tranfer type")
 	}
 	result := &TransferResponse{}
 	json.Unmarshal(e.data, result)
@@ -264,7 +264,7 @@ func (e EventResponse) TransferData() (*TransferResponse, error) {
 // DeleteData は、イベントの種類がDeleteEventの時にDeleteResponse構造体を返します。
 func (e EventResponse) DeleteData() (*DeleteResponse, error) {
 	if e.ResultType != DeleteEvent {
-		return nil, errors.New("This event is not delete type.")
+		return nil, errors.New("this event is not delete type")
 	}
 	result := &DeleteResponse{}
 	json.Unmarshal(e.data, result)

--- a/v1/plan.go
+++ b/v1/plan.go
@@ -95,7 +95,7 @@ func (p PlanService) Create(plan Plan) (*PlanResponse, error) {
 	return parsePlan(p.service, body, &PlanResponse{})
 }
 
-// Get は特定のプラン情報を取得します。
+// Retrieve plan object. 特定のプラン情報を取得します。
 func (p PlanService) Retrieve(id string) (*PlanResponse, error) {
 	body, err := p.service.retrieve("/plans/" + id)
 	if err != nil {

--- a/v1/subscription.go
+++ b/v1/subscription.go
@@ -109,7 +109,7 @@ func (s SubscriptionService) Subscribe(customerID string, subscription Subscript
 	return parseSubscription(s.service, body, &SubscriptionResponse{})
 }
 
-// Get は生成した特定の定期課金情報を取得します。
+// Retrieve subscription object. 特定の定期課金情報を取得します。
 func (s SubscriptionService) Retrieve(customerID, subscriptionID string) (*SubscriptionResponse, error) {
 	body, err := s.service.retrieve("/customers/" + customerID + "/subscriptions/" + subscriptionID)
 	if err != nil {

--- a/v1/subscription_example_test.go
+++ b/v1/subscription_example_test.go
@@ -23,20 +23,20 @@ func TestSubscriptionExample(t *testing.T) {
         t.Errorf("plan create error")
         fmt.Println("err:", err)
     }
-    set_subscr, err := service.Subscription.Update(id, Subscription{
+    setSubscr, err := service.Subscription.Update(id, Subscription{
         NextCyclePlanID: plan.ID,
     })
-    if err != nil || set_subscr.NextCyclePlan.ID != plan.ID {
+    if err != nil || setSubscr.NextCyclePlan.ID != plan.ID {
         t.Errorf("subscription update error with NextCyclePlan")
     }
-    fmt.Println("NextCyclePlan:", set_subscr.NextCyclePlan)
-    del_subscr, err := service.Subscription.Update(id, Subscription{
+    fmt.Println("NextCyclePlan:", setSubscr.NextCyclePlan)
+    delSubscr, err := service.Subscription.Update(id, Subscription{
         NextCyclePlanID: "",
     })
-    if err != nil || del_subscr.NextCyclePlan != nil {
+    if err != nil || delSubscr.NextCyclePlan != nil {
         t.Errorf("subscription update error without NextCyclePlan")
     }
-    fmt.Println("NextCyclePlan:", del_subscr.NextCyclePlan)
+    fmt.Println("NextCyclePlan:", delSubscr.NextCyclePlan)
     if service.Plan.Delete(plan.ID) != nil {
         t.Errorf("plan delete error")
         fmt.Println("err:", err)

--- a/v1/subscription_test.go
+++ b/v1/subscription_test.go
@@ -281,13 +281,13 @@ func TestSubscriptionUpdate(t *testing.T) {
 
 	mock2, transport2 := NewMockClient(200, nextCyclePlanNullResponseJSON)
 	service2 := New("api-key", mock2)
-	new_subscr, err := service2.Subscription.Update("sub_567a1e44562932ec1a7682d746e0", Subscription{
+	newSubscr, err := service2.Subscription.Update("sub_567a1e44562932ec1a7682d746e0", Subscription{
 		NextCyclePlanID: "",
 	})
 	if transport2.Method != "POST" {
 		t.Errorf("Method should be POST, but %s", transport2.Method)
 	}
-	if new_subscr.NextCyclePlan != nil {
+	if newSubscr.NextCyclePlan != nil {
 		t.Errorf("subscription.NextCyclePlan is not nil")
 	}
 }

--- a/v1/token.go
+++ b/v1/token.go
@@ -76,7 +76,7 @@ func (t TokenService) Create(card Card) (*TokenResponse, error) {
 	return parseToken(respToBody(t.service.Client.Do(request)))
 }
 
-// Get メソッドは特定のトークン情報を取得します。
+// Retrieve token object. 特定のトークン情報を取得します。
 func (t TokenService) Retrieve(id string) (*TokenResponse, error) {
 	return parseToken(t.service.retrieve("/tokens/" + id))
 }

--- a/v1/transfer.go
+++ b/v1/transfer.go
@@ -48,7 +48,7 @@ func newTransferService(service *Service) *TransferService {
 	}
 }
 
-// Get は特定の入金情報を取得します。
+// Retrieve transfer object. 入金情報を取得します。
 func (t TransferService) Retrieve(transferID string) (*TransferResponse, error) {
 	body, err := t.service.retrieve("/transfers/" + transferID)
 	if err != nil {


### PR DESCRIPTION
# abstract

golangのサポートバージョンを更新する

- stable: https://golang.org/dl/ 
- `go get golang.org` がサポートしている1.9以上を目安にサポート

fix the following lint errors.

- comment on exported method ... should be of the form ...
- error strings should not be capitalized or end with punctuation or a newline
- don't use underscores in Go names; var set_subscr should be setSubscr

# check

- [x] pass lint
- [x] pass tests