### PR TITLE
組戻ステータスの追加

### DIFF
--- a/v1/transfer.go
+++ b/v1/transfer.go
@@ -19,6 +19,8 @@ const (
 	TransferFailed
 	// TransferCanceled は支払いキャンセルのステータスを表す定数
 	TransferCanceled
+  // TransferRecombination は組戻ステータスを表す定数
+  TransferRecombination
 )
 
 func (t TransferStatus) status() interface{} {
@@ -31,6 +33,8 @@ func (t TransferStatus) status() interface{} {
 		return "failed"
 	case TransferCanceled:
 		return "canceled"
+  case TransferRecombination:
+    return "recombination"
 	}
 	return nil
 }
@@ -294,6 +298,8 @@ func (t *TransferResponse) UnmarshalJSON(b []byte) error {
 			t.Status = TransferFailed
 		case "canceled":
 			t.Status = TransferCanceled
+    case "recombination":
+      t.Status = TransferRecombination
 		}
 		t.Summary.ChargeCount = raw.Summary.ChargeCount
 		t.Summary.ChargeFee = raw.Summary.ChargeFee

--- a/v1/transfer.go
+++ b/v1/transfer.go
@@ -19,8 +19,8 @@ const (
 	TransferFailed
 	// TransferCanceled は支払いキャンセルのステータスを表す定数
 	TransferCanceled
-  // TransferRecombination は組戻ステータスを表す定数
-  TransferRecombination
+	// TransferRecombination は組戻ステータスを表す定数
+	TransferRecombination
 )
 
 func (t TransferStatus) status() interface{} {
@@ -33,8 +33,8 @@ func (t TransferStatus) status() interface{} {
 		return "failed"
 	case TransferCanceled:
 		return "canceled"
-  case TransferRecombination:
-    return "recombination"
+	case TransferRecombination:
+		return "recombination"
 	}
 	return nil
 }
@@ -298,8 +298,8 @@ func (t *TransferResponse) UnmarshalJSON(b []byte) error {
 			t.Status = TransferFailed
 		case "canceled":
 			t.Status = TransferCanceled
-    case "recombination":
-      t.Status = TransferRecombination
+		case "recombination":
+			t.Status = TransferRecombination
 		}
 		t.Summary.ChargeCount = raw.Summary.ChargeCount
 		t.Summary.ChargeFee = raw.Summary.ChargeFee

--- a/v1/transfer_test.go
+++ b/v1/transfer_test.go
@@ -79,6 +79,79 @@ var transferResponseJSON = []byte(`
 }
 `)
 
+var recombinationTransferResponseJSON = []byte(`
+{
+  "amount": 1000,
+  "carried_balance": null,
+  "charges": {
+    "count": 1,
+    "data": [
+      {
+        "amount": 1000,
+        "amount_refunded": 0,
+        "captured": true,
+        "captured_at": 1441706750,
+        "card": {
+          "address_city": null,
+          "address_line1": null,
+          "address_line2": null,
+          "address_state": null,
+          "address_zip": null,
+          "address_zip_check": "unchecked",
+          "brand": "Visa",
+          "country": null,
+          "created": 1441706750,
+          "cvc_check": "unchecked",
+          "exp_month": 5,
+          "exp_year": 2018,
+          "fingerprint": "e1d8225886e3a7211127df751c86787f",
+          "id": "car_93e59e9a9714134ef639865e2b9e",
+          "last4": "4242",
+          "name": null,
+          "object": "card"
+        },
+        "created": 1441706750,
+        "currency": "jpy",
+        "customer": "cus_b92b879e60f62b532d6756ae12af",
+        "description": null,
+        "expired_at": null,
+        "failure_code": null,
+        "failure_message": null,
+        "id": "ch_60baaf2dc8f3e35684ebe2031a6e0",
+        "object": "charge",
+        "paid": true,
+        "refund_reason": null,
+        "refunded": false,
+        "subscription": null
+      }
+    ],
+    "has_more": false,
+    "object": "list",
+    "url": "/v1/transfers/tr_8f0c0fe2c9f8a47f9d18f03959ba1/charges"
+  },
+  "created": 1438354800,
+  "currency": "jpy",
+  "description": null,
+  "id": "tr_8f0c0fe2c9f8a47f9d18f03959ba1",
+  "livemode": false,
+  "object": "transfer",
+  "scheduled_date": "2015-09-16",
+  "status": "recombination",
+  "summary": {
+    "charge_count": 1,
+    "charge_fee": 0,
+    "charge_gross": 1000,
+    "net": 1000,
+    "refund_amount": 0,
+    "refund_count": 0
+  },
+  "term_end": 1439650800,
+  "term_start": 1438354800,
+  "transfer_amount": null,
+  "transfer_date": null
+}
+`)
+
 var transferListResponseJSON = []byte(`
 {
   "count": 1,
@@ -224,6 +297,21 @@ func TestParseTransferResponseJSON(t *testing.T) {
 	if transfer.Charges[0].ID != "ch_60baaf2dc8f3e35684ebe2031a6e0" {
 		t.Errorf("Charge.ID should be 'ch_60baaf2dc8f3e35684ebe2031a6e0', but '%s'", transfer.Charges[0].ID)
 	}
+  if transfer.Status.status() != "pending" {
+		t.Errorf("transfer.Status should be 'pending', but '%s'", transfer.Status.status())
+  }
+}
+
+func TestParseRecombinationTransferResponseJSON(t *testing.T) {
+  recombinationTransfer := &TransferResponse{}
+  err := json.Unmarshal(recombinationTransferResponseJSON, recombinationTransfer)
+
+	if err != nil {
+		t.Errorf("err should be nil, but %v", err)
+	}
+  if recombinationTransfer.Status.status() != "recombination" {
+		t.Errorf("transfer.Status should be 'recombination', but '%s'", recombinationTransfer.Status.status())
+  }
 }
 
 func TestTransferRetrieve(t *testing.T) {

--- a/v1/transfer_test.go
+++ b/v1/transfer_test.go
@@ -297,21 +297,21 @@ func TestParseTransferResponseJSON(t *testing.T) {
 	if transfer.Charges[0].ID != "ch_60baaf2dc8f3e35684ebe2031a6e0" {
 		t.Errorf("Charge.ID should be 'ch_60baaf2dc8f3e35684ebe2031a6e0', but '%s'", transfer.Charges[0].ID)
 	}
-  if transfer.Status.status() != "pending" {
+	if transfer.Status.status() != "pending" {
 		t.Errorf("transfer.Status should be 'pending', but '%s'", transfer.Status.status())
-  }
+	}
 }
 
 func TestParseRecombinationTransferResponseJSON(t *testing.T) {
-  recombinationTransfer := &TransferResponse{}
-  err := json.Unmarshal(recombinationTransferResponseJSON, recombinationTransfer)
+	recombinationTransfer := &TransferResponse{}
+	err := json.Unmarshal(recombinationTransferResponseJSON, recombinationTransfer)
 
 	if err != nil {
 		t.Errorf("err should be nil, but %v", err)
 	}
-  if recombinationTransfer.Status.status() != "recombination" {
+	if recombinationTransfer.Status.status() != "recombination" {
 		t.Errorf("transfer.Status should be 'recombination', but '%s'", recombinationTransfer.Status.status())
-  }
+	}
 }
 
 func TestTransferRetrieve(t *testing.T) {


### PR DESCRIPTION
http://payjp-announce.hatenablog.com/entry/2020/02/14/174049 にて、2020/02/29入金予定分以降の入金失敗は組戻(recombination)と表されるので、その対応