### PR TITLE
capture の金額指定を可能にする

### DIFF
--- a/v1/charge.go
+++ b/v1/charge.go
@@ -171,7 +171,9 @@ func (c ChargeService) Refund(chargeID, reason string, amount ...int) (*ChargeRe
 	return parseCharge(c.service, body, &ChargeResponse{})
 }
 
-func (c ChargeService) capture(chargeID string, amount ...int) ([]byte, error) {
+
+
+func (c ChargeService) capture(chargeID string, amount []int) ([]byte, error) {
 	qb := newRequestBuilder()
 	if len(amount) > 0 {
 		qb.Add("amount", amount[0])
@@ -192,8 +194,8 @@ func (c ChargeService) capture(chargeID string, amount ...int) ([]byte, error) {
 // amount をセットした場合、AmountRefunded に認証時の amount との差額が入ります。
 //
 // 例えば、認証時に amount=500 で作成し、 amount=400 で支払い確定を行った場合、 AmountRefunded=100 となり、確定金額が400円に変更された状態で支払いが確定されます。
-func (c ChargeService) Capture(chargeID string) (*ChargeResponse, error) {
-	body, err := c.capture(chargeID)
+func (c ChargeService) Capture(chargeID string, amount ...int) (*ChargeResponse, error) {
+	body, err := c.capture(chargeID, amount)
 	if err != nil {
 		return nil, err
 	}
@@ -363,8 +365,8 @@ func (c *ChargeResponse) Refund(reason string, amount ...int) error {
 // amount をセットした場合、AmountRefunded に認証時の amount との差額が入ります。
 //
 // 例えば、認証時に amount=500 で作成し、 amount=400 で支払い確定を行った場合、 AmountRefunded=100 となり、確定金額が400円に変更された状態で支払いが確定されます。
-func (c *ChargeResponse) Capture() error {
-	body, err := c.service.Charge.capture(c.ID)
+func (c *ChargeResponse) Capture(amount ...int) error {
+	body, err := c.service.Charge.capture(c.ID, amount)
 	if err != nil {
 		return err
 	}

--- a/v1/charge_test.go
+++ b/v1/charge_test.go
@@ -159,7 +159,7 @@ func TestChargeCreateByNonDefaultard(t *testing.T) {
 	mock, transport := NewMockClient(200, chargeResponseJSON)
 	service := New("api-key", mock)
 	charge, err := service.Charge.Create(1000, Charge{
-		CustomerID: "cus_xxxxxxxxx",
+		CustomerID:     "cus_xxxxxxxxx",
 		CustomerCardID: "car_xxxxxxxxx",
 	})
 
@@ -300,6 +300,21 @@ func TestChargeCapture(t *testing.T) {
 	}
 }
 
+func TestServiceChargeCaptureChangeAmount(t *testing.T) {
+	mock, transport := NewMockClient(200, chargeResponseJSON)
+	service := New("api-key", mock)
+	_, err := service.Charge.Capture("ch_fa990a4c10672a93053a774730b0a", 300)
+	if transport.URL != "https://api.pay.jp/v1/charges/ch_fa990a4c10672a93053a774730b0a/capture" {
+		t.Errorf("URL is wrong: %s", transport.URL)
+	}
+	if transport.Method != "POST" {
+		t.Errorf("Method should be POST, but %s", transport.Method)
+	}
+	if err != nil {
+		t.Errorf("err should be nil, but %v", err)
+	}
+}
+
 func TestChargeCapture2(t *testing.T) {
 	mock, transport := NewMockClient(200, chargeResponseJSON)
 	service := New("api-key", mock)
@@ -323,14 +338,14 @@ func TestChargeCapture2(t *testing.T) {
 func TestChargeCaptureChangedAmount(t *testing.T) {
 	mock, transport := NewMockClient(200, chargeResponseJSON)
 	service := New("api-key", mock)
-  chargeID := "ch_fa990a4c10672a93053a774730b0a"
+	chargeID := "ch_fa990a4c10672a93053a774730b0a"
 	charge, err := service.Charge.Retrieve(chargeID)
-  newAmount := 100
-  err = charge.Capture(newAmount)
+	newAmount := 100
+	err = charge.Capture(newAmount)
 	if err != nil {
 		t.Errorf("err should be nil, but %v", err)
 	}
-	if transport.URL != "https://api.pay.jp/v1/charges/" + chargeID + "/capture" {
+	if transport.URL != "https://api.pay.jp/v1/charges/"+chargeID+"/capture" {
 		t.Errorf("URL is wrong: %s", transport.URL)
 	}
 	if transport.Method != "POST" {

--- a/v1/charge_test.go
+++ b/v1/charge_test.go
@@ -320,6 +320,24 @@ func TestChargeCapture2(t *testing.T) {
 	}
 }
 
+func TestChargeCaptureChangedAmount(t *testing.T) {
+	mock, transport := NewMockClient(200, chargeResponseJSON)
+	service := New("api-key", mock)
+  chargeID := "ch_fa990a4c10672a93053a774730b0a"
+	charge, err := service.Charge.Retrieve(chargeID)
+  newAmount := 100
+  err = charge.Capture(newAmount)
+	if err != nil {
+		t.Errorf("err should be nil, but %v", err)
+	}
+	if transport.URL != "https://api.pay.jp/v1/charges/" + chargeID + "/capture" {
+		t.Errorf("URL is wrong: %s", transport.URL)
+	}
+	if transport.Method != "POST" {
+		t.Errorf("Method should be POST, but %s", transport.Method)
+	}
+}
+
 func TestChargeList(t *testing.T) {
 	mock, transport := NewMockClient(200, chargeListResponseJSON)
 	service := New("api-key", mock)


### PR DESCRIPTION
Charge.Capture の引数に amount の指定ができない状態だったので、現在のcaptureエンドポイントに合わせてamountを指定可能にする