### PR TITLE
Fix installation problem caused by invalid path in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module v1
+module github.com/payjp/payjp-go
 
 go 1.15


### PR DESCRIPTION
I faced this error when following the [installation instructions](https://github.com/rbmrclo/payjp-go#installation):
```
 > [3/3] RUN go get github.com/payjp/payjp-go/v1:
#6 0.892 go: downloading github.com/payjp/payjp-go v0.0.0-20201217084407-4e27e7ecbe9f
#6 1.759 go: found github.com/payjp/payjp-go/v1 in github.com/payjp/payjp-go v0.0.0-20201217084407-4e27e7ecbe9f
#6 1.839 go get: github.com/payjp/payjp-go@v0.0.0-20201217084407-4e27e7ecbe9f: parsing go.mod:
#6 1.839 	module declares its path as: v1
#6 1.839 	        but was required as: github.com/payjp/payjp-go
```

On another note, I found out that there was a similar issue for this problem so I have confirmed that I'm not only the one experiencing the problem.
- https://github.com/payjp/payjp-go/issues/25

I've updated `go.mod` and presented a demo to confirm this fix using docker to ensure that this is not an environment-related issue. Kindly check it here:
- https://github.com/rbmrclo/payjp-error-demo