### PR TITLE
入金リストAPIに引数追加

### DIFF
--- a/v1/client.go
+++ b/v1/client.go
@@ -90,6 +90,14 @@ func (s Service) delete(resourceURL string) error {
 }
 
 func (s Service) queryList(resourcePath string, limit, offset, since, until int, callbacks ...func(*url.Values) bool) ([]byte, error) {
+	return s.queryListAll(resourcePath, limit, offset, since, until, 0, 0, callbacks...)
+}
+
+func (s Service) queryTransferList(resourcePath string, limit, offset, since, until, sinceSheduledDate, untilSheduledDate int, callbacks ...func(*url.Values) bool) ([]byte, error) {
+	return s.queryListAll(resourcePath, limit, offset, since, until, sinceSheduledDate, untilSheduledDate, callbacks...)
+}
+
+func (s Service) queryListAll(resourcePath string, limit, offset, since, until, sinceSheduledDate, untilSheduledDate int, callbacks ...func(*url.Values) bool) ([]byte, error) {
 	if limit < 0 || limit > 100 {
 		return nil, fmt.Errorf("method Limit() should be between 1 and 100, but %d", limit)
 	}
@@ -110,6 +118,14 @@ func (s Service) queryList(resourcePath string, limit, offset, since, until int,
 	}
 	if until != 0 {
 		values.Add("until", strconv.Itoa(until))
+		hasParam = true
+	}
+	if sinceSheduledDate != 0 {
+		values.Add("since_sheduled_date", strconv.Itoa(sinceSheduledDate))
+		hasParam = true
+	}
+	if untilSheduledDate != 0 {
+		values.Add("until_sheduled_date", strconv.Itoa(untilSheduledDate))
 		hasParam = true
 	}
 	// add extra parameters

--- a/v1/transfer.go
+++ b/v1/transfer.go
@@ -82,6 +82,8 @@ type TransferListCaller struct {
 	offset  int
 	since   int
 	until   int
+	sinceSheduledDate   int
+	untilSheduledDate   int
 	status  TransferStatus
 }
 
@@ -94,6 +96,18 @@ func (c *TransferListCaller) Limit(limit int) *TransferListCaller {
 // Offset は取得するリストの先頭要素のインデックスのオフセットを設定します
 func (c *TransferListCaller) Offset(offset int) *TransferListCaller {
 	c.offset = offset
+	return c
+}
+
+// SinceSheduledDate は入金予定日がここに指定したタイムスタンプ以降のデータのみ取得します
+func (c *TransferListCaller) SinceSheduledDate(sinceSheduledDate time.Time) *TransferListCaller {
+	c.sinceSheduledDate = int(sinceSheduledDate.Unix())
+	return c
+}
+
+// UntilSheduledDate は入金予定日がここに指定したタイムスタンプ以前のデータのみ取得します
+func (c *TransferListCaller) UntilSheduledDate(untilSheduledDate time.Time) *TransferListCaller {
+	c.untilSheduledDate = int(untilSheduledDate.Unix())
 	return c
 }
 
@@ -117,7 +131,7 @@ func (c *TransferListCaller) Status(status TransferStatus) *TransferListCaller {
 
 // Do は指定されたクエリーを元に入金のリストを配列で取得します。
 func (c *TransferListCaller) Do() ([]*TransferResponse, bool, error) {
-	body, err := c.service.queryList("/transfers", c.limit, c.offset, c.since, c.until, func(values *url.Values) bool {
+	body, err := c.service.queryTransferList("/transfers", c.limit, c.offset, c.since, c.until, c.sinceSheduledDate, c.untilSheduledDate, func(values *url.Values) bool {
 		if c.status != noTransferStatus {
 			values.Add("status", c.status.status().(string))
 			return true


### PR DESCRIPTION
- since_scheduled_date, until_scheduled_date追加
- https://pay.jp/docs/api/#%E5%85%A5%E9%87%91%E3%83%AA%E3%82%B9%E3%83%88%E3%82%92%E5%8F%96%E5%BE%97
- https://pay.jp/docs/api/#%E3%83%86%E3%83%8A%E3%83%B3%E3%83%88%E3%81%AE%E5%85%A5%E9%87%91%E3%83%AA%E3%82%B9%E3%83%88%E3%82%92%E5%8F%96%E5%BE%97