### PR TITLE
fix: update description

### DIFF
--- a/v1/charge.go
+++ b/v1/charge.go
@@ -116,7 +116,7 @@ func (c ChargeService) Retrieve(chargeID string) (*ChargeResponse, error) {
 
 func (c ChargeService) update(chargeID, description string, metadata map[string]string) ([]byte, error) {
 	qb := newRequestBuilder()
-	qb.Add("name", description)
+	qb.Add("description", description)
 	qb.AddMetadata(metadata)
 	request, err := http.NewRequest("POST", c.service.apiBase+"/charges/"+chargeID, qb.Reader())
 	if err != nil {


### PR DESCRIPTION
The `ChargeService.update` method results in an error.
```
400: Type: client_error Code: invalid_param_key Message: Invalid param key to charge, Param: name
```

I think the key string on line 119 of `ChargeService.update` will be `description` instead of `name`.

There are also some changes due to the code format (go fmt).

Thank you.