### PR TITLE
EventResponseをjsonとしてmarshal可能にする

### DIFF
--- a/v1/event.go
+++ b/v1/event.go
@@ -279,8 +279,6 @@ type eventResponseParser struct {
 	Object          string          `json:"object"`
 	PendingWebHooks int             `json:"pending_webhooks"`
 	Type            string          `json:"type"`
-
-	CreatedAt time.Time
 }
 
 // UnmarshalJSON はJSONパース用の内部APIです。
@@ -305,6 +303,19 @@ func (e *EventResponse) UnmarshalJSON(b []byte) error {
 	}
 
 	return nil
+}
+
+// MarshalJSON はリクエストボディをAPI仕様のJson形式で返します。
+func (e *EventResponse) MarshalJSON() ([]byte, error) {
+	raw := eventResponseParser{}
+	raw.Object = "event"
+	raw.CreatedEpoch = int(e.CreatedAt.Unix())
+	raw.Data = e.data
+	raw.ID = e.ID
+	raw.LiveMode = e.LiveMode
+	raw.PendingWebHooks = e.PendingWebHooks
+	raw.Type = e.Type
+	return json.Marshal(&raw)
 }
 
 // DeleteResponse はイベントの種類がDeleteEventの時にDeleteData()が返す構造体です。

--- a/v1/event_test.go
+++ b/v1/event_test.go
@@ -1,6 +1,7 @@
 package payjp
 
 import (
+	"bytes"
 	"encoding/json"
 	"testing"
 	"time"
@@ -114,6 +115,18 @@ func TestParseEventResponseJSON(t *testing.T) {
 	}
 	if event.ResultType != CustomerEvent {
 		t.Errorf("parse error: %v", event.ResultType)
+	}
+
+	marshaledJSON, err := json.Marshal(&event)
+	if err != nil {
+		t.Errorf("error should be nil, but %v", err)
+	}
+	compactedEventResponseJSON := bytes.NewBuffer([]byte{})
+	if err := json.Compact(compactedEventResponseJSON, eventResponseJSON); err != nil {
+		t.Errorf("error should be nil, but %v", err)
+	}
+	if string(marshaledJSON) != compactedEventResponseJSON.String() {
+		t.Errorf("marshaledJSON should be same with eventResponseJSON, but %s", string(marshaledJSON))
 	}
 
 	card, err := event.CardData()


### PR DESCRIPTION
mysqlへjson型として、その時のeventのスナップショットを記録しようとしているのですが、EventResponseを元のjsonとして取得できるインターフェースがないため、追加しました。
既存箇所への動作変更などないため、マージしていただきたいです。