### PR TITLE
expiry_daysの値チェックロジックが間違っている

### DIFF
--- a/v1/charge.go
+++ b/v1/charge.go
@@ -67,7 +67,7 @@ func (c ChargeService) Create(amount int, charge Charge) (*ChargeResponse, error
 		errorMessages = append(errorMessages, fmt.Sprintf("Only supports 'jpy' as currency, but '%s'.", charge.Currency))
 	}
 	expireDays, ok := charge.ExpireDays.(int)
-	if ok && (expireDays < -1 || expireDays > 60) {
+	if ok && (expireDays < 1 || expireDays > 60) {
 		errorMessages = append(errorMessages, fmt.Sprintf("ExpireDays should be between 1 and 60, but %d.", expireDays))
 	}
 	if len(errorMessages) > 0 {

--- a/v1/charge_test.go
+++ b/v1/charge_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 	"strings"
+	"fmt"
 )
 
 var chargeResponseJSON = []byte(`

--- a/v1/charge_test.go
+++ b/v1/charge_test.go
@@ -160,9 +160,9 @@ func TestChargeCreate(t *testing.T) {
 }
 
 func TestChargeCannotCreateWithInvalidExpireDays(t *testing.T) {
-	mock, transport := NewMockClient(200, chargeResponseJSON)
+	mock, _ := NewMockClient(200, chargeResponseJSON)
 	service := New("api-key", mock)
-	charge, err := service.Charge.Create(1000, Charge{
+	_, err := service.Charge.Create(1000, Charge{
 		Capture: false,
 		ExpireDays: 0,
 	})

--- a/v1/charge_test.go
+++ b/v1/charge_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 	"time"
+	"strings"
 )
 
 var chargeResponseJSON = []byte(`
@@ -154,6 +155,19 @@ func TestChargeCreate(t *testing.T) {
 		t.Error("charge should not be nil")
 	} else if charge.Amount != 3500 {
 		t.Errorf("charge.Amount should be 3500, but %d.", charge.Amount)
+	}
+}
+
+func TestChargeCannotCreateWithInvalidExpireDays(t *testing.T) {
+	mock, transport := NewMockClient(200, chargeResponseJSON)
+	service := New("api-key", mock)
+	charge, err := service.Charge.Create(1000, Charge{
+		Capture: false,
+		ExpireDays: 0,
+	})
+	if !strings.Contains(fmt.Sprint(err), "ExpireDays should be between 1 and 60, but 0") {
+		t.Errorf("err should not be nil")
+		return
 	}
 }
 


### PR DESCRIPTION
- https://pay.jp/docs/api/#%E6%94%AF%E6%89%95%E3%81%84%E3%82%92%E4%BD%9C%E6%88%90 の通り、expiry_daysは1~60の値が指定可能だが/v1/charge.goのCharge.Create内のチェックロジックでは-1,0が指定可能となってしまっていた https://github.com/payjp/payjp-go/blob/caa439e37561d5e764a79c1c60eabace1f643e9d/v1/charge.go#L69-L72
- 値を修正、テストを追加