### PR TITLE
Refactor client configuration for logging

### DIFF
--- a/v1/client.go
+++ b/v1/client.go
@@ -51,7 +51,7 @@ func WithMaxDelay(maxDelay float64) serviceConfig {
 
 // WithLogger はログ出力を変更するために使用します。
 //
-// デフォルトではWARN, ERRORのログが標準エラーに出力されます。
+// デフォルトではログは出力されません。
 // LoggerInterfaceを実装した構造体を渡すことでログ出力を変更できます。
 func WithLogger(logger LoggerInterface) serviceConfig {
 	return func(s *Service) {
@@ -119,7 +119,7 @@ func New(apiKey string, client *http.Client, configs ...serviceConfig) *Service 
 	service.MaxCount = defaultMaxCount
 	service.InitialDelay = defaultInitialDelay
 	service.MaxDelay = defaultMaxDelay
-	service.Logger = DefaultLogger
+	service.Logger = NullLogger
 
 	for _, c := range configs {
 		c(service)

--- a/v1/client.go
+++ b/v1/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
-	"log"
 	"math"
 	"math/rand"
 	"net/http"
@@ -51,7 +50,10 @@ func WithMaxDelay(maxDelay float64) serviceConfig {
 }
 
 // WithLogger はログ出力を変更するために使用します。
-func WithLogger(logger *log.Logger) serviceConfig {
+//
+// デフォルトではWARN, ERRORのログが標準エラーに出力されます。
+// LoggerInterfaceを実装した構造体を渡すことでログ出力を変更できます。
+func WithLogger(logger LoggerInterface) serviceConfig {
 	return func(s *Service) {
 		s.Logger = logger
 	}
@@ -85,7 +87,7 @@ type Service struct {
 	MaxCount     int
 	InitialDelay float64
 	MaxDelay     float64
-	Logger       *log.Logger
+	Logger       LoggerInterface
 
 	Charge       *ChargeService
 	Customer     *CustomerService
@@ -117,6 +119,7 @@ func New(apiKey string, client *http.Client, configs ...serviceConfig) *Service 
 	service.MaxCount = defaultMaxCount
 	service.InitialDelay = defaultInitialDelay
 	service.MaxDelay = defaultMaxDelay
+	service.Logger = DefaultLogger
 
 	for _, c := range configs {
 		c(service)
@@ -207,7 +210,7 @@ func (s Service) request(method, path string, body io.Reader, headerMap ...map[s
 		}
 		delay := time.Duration(s.getRetryDelay(currentRetryCount)*1000) * time.Millisecond
 		if logger != nil {
-			logger.Printf("Current Retry Count: %d. Retry after %v", currentRetryCount+1, delay)
+			logger.Infof("Current Retry Count: %d. Retry after %v", currentRetryCount+1, delay)
 		}
 		time.Sleep(delay)
 		resp, err = s.Client.Do(request)

--- a/v1/client_test.go
+++ b/v1/client_test.go
@@ -58,7 +58,7 @@ func TestNew(t *testing.T) {
 	assert.EqualValues(t, 0, service.MaxCount)
 	assert.EqualValues(t, 2, service.InitialDelay)
 	assert.EqualValues(t, 32, service.MaxDelay)
-	assert.EqualValues(t, service.Logger, DefaultLogger)
+	assert.EqualValues(t, service.Logger, NullLogger)
 
 	client := &http.Client{}
 	assert.NotSame(t, client, service.Client)

--- a/v1/examples/account/main.go
+++ b/v1/examples/account/main.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/payjp/payjp-go/v1"
 )
@@ -51,16 +50,13 @@ func con(pay *payjp.Service, x int) {
 }
 
 func main() {
-	var buf bytes.Buffer
-	logger := log.New(&buf, "example_", log.Lshortfile)
 	pay := payjp.New(
 		"sk_test_c62fade9d045b54cd76d7036",
 		nil,
 		payjp.WithMaxCount(5),
 		// payjp.WithMaxDelay(1),
 		// payjp.WithInitialDelay(0.001),
-		payjp.WithLogger(logger),
+		payjp.WithLogger(payjp.NewPayjpLogger(payjp.LogLevelInfo)),
 	)
 	con(pay, 30)
-	fmt.Println(buf.String())
 }

--- a/v1/log.go
+++ b/v1/log.go
@@ -1,0 +1,88 @@
+package payjp
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// LogLevel はログの出力レベルを表します。
+type LogLevel int
+
+const (
+	LogLevelNull  LogLevel = 0
+	LogLevelError LogLevel = 1
+	LogLevelWarn  LogLevel = 2
+	LogLevelInfo  LogLevel = 3
+	LogLevelDebug LogLevel = 4
+)
+
+// LoggerInterface はログ出力を行うためのインターフェースです。
+type LoggerInterface interface {
+	Debugf(format string, args ...interface{})
+	Infof(format string, args ...interface{})
+	Warnf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+}
+
+// DefaultLogger はデフォルトのロガーです。
+// WARN, ERRORのログが標準エラーに出力されます。
+var DefaultLogger LoggerInterface = NewPayjpLogger(LogLevelWarn)
+
+// NullLogger はログを出力しないロガーです。
+var NullLogger LoggerInterface = NewPayjpLogger(LogLevelNull)
+
+type PayjpLogger struct {
+	logLevel LogLevel
+
+	stdoutOverride io.Writer
+	stderrOverride io.Writer
+}
+
+var _ LoggerInterface = &PayjpLogger{}
+
+// NewPayjpLogger はPayjpLoggerを生成します。
+// ログの出力レベルを指定することができます。
+func NewPayjpLogger(logLevel LogLevel) *PayjpLogger {
+	return &PayjpLogger{logLevel: logLevel}
+}
+
+func (l *PayjpLogger) stdout() io.Writer {
+	if l.stdoutOverride != nil {
+		return l.stdoutOverride
+	}
+
+	return os.Stdout
+}
+
+func (l *PayjpLogger) stderr() io.Writer {
+	if l.stderrOverride != nil {
+		return l.stderrOverride
+	}
+
+	return os.Stderr
+}
+
+func (l *PayjpLogger) Debugf(format string, args ...interface{}) {
+	if l.logLevel >= LogLevelDebug {
+		fmt.Fprintf(l.stdout(), "[DEBUG] "+format+"\n", args...)
+	}
+}
+
+func (l *PayjpLogger) Infof(format string, args ...interface{}) {
+	if l.logLevel >= LogLevelInfo {
+		fmt.Fprintf(l.stdout(), "[INFO] "+format+"\n", args...)
+	}
+}
+
+func (l *PayjpLogger) Warnf(format string, args ...interface{}) {
+	if l.logLevel >= LogLevelWarn {
+		fmt.Fprintf(l.stderr(), "[WARN] "+format+"\n", args...)
+	}
+}
+
+func (l *PayjpLogger) Errorf(format string, args ...interface{}) {
+	if l.logLevel >= LogLevelError {
+		fmt.Fprintf(l.stderr(), "[ERROR] "+format+"\n", args...)
+	}
+}

--- a/v1/log.go
+++ b/v1/log.go
@@ -25,10 +25,6 @@ type LoggerInterface interface {
 	Errorf(format string, args ...interface{})
 }
 
-// DefaultLogger はデフォルトのロガーです。
-// WARN, ERRORのログが標準エラーに出力されます。
-var DefaultLogger LoggerInterface = NewPayjpLogger(LogLevelWarn)
-
 // NullLogger はログを出力しないロガーです。
 var NullLogger LoggerInterface = NewPayjpLogger(LogLevelNull)
 


### PR DESCRIPTION
ライブラリ内部でのロギングを設定するための `LoggerInterface` を追加しました

`WithLogger` に `LoggerInterface` を実装したstructを渡してライブラリ内でのロギングの挙動をカスタマイズすることができます

デフォルトではログを出力しない `NullLogger` を設定します
出力するログレベルのみを変更するための `NewPayjpLogger` も公開します