### PR TITLE
update: add statement url to balance object.

### DIFF
--- a/v1/balance.go
+++ b/v1/balance.go
@@ -25,6 +25,24 @@ func newBalanceService(service *Service) *BalanceService {
 	}
 }
 
+func (s *BalanceResponse) StatementUrls(p ...StatementUrls) (*StatementUrlResponse, error) {
+	qb := newRequestBuilder()
+	if len(p) > 0 {
+		qb.Add("platformer", p[0].Platformer)
+	}
+
+	body, err := s.service.request("POST", "/balances/"+s.ID+"/statement_urls", qb.Reader())
+	if err != nil {
+		return nil, err
+	}
+	result := &StatementUrlResponse{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 // Retrieve transfer object. 入金情報を取得します。
 func (t BalanceService) Retrieve(id string) (*BalanceResponse, error) {
 	body, err := t.service.request("GET", "/balances/"+id, nil)

--- a/v1/balance_test.go
+++ b/v1/balance_test.go
@@ -25,13 +25,6 @@ func makeBalanceJSONStr(bank string, d string) string {
 var balanceJSONStr = makeBalanceJSONStr("null", "null")
 
 var balanceResponseJSON = []byte(balanceJSONStr)
-var balanceStatementUrlsResponseJSON = []byte(`
-{
-  "expires": 1695903280,
-  "object": "statement_url",
-  "url": "url"
-}
-`)
 
 var balanceListJSONStr = `
 {

--- a/v1/balance_test.go
+++ b/v1/balance_test.go
@@ -131,9 +131,9 @@ func TestBalance(t *testing.T) {
 func TestBalanceStatementUrls(t *testing.T) {
 	mock, transport := newMockClient(200, balanceResponseJSON)
 	transport.AddResponse(400, errorResponseJSON)
-	transport.AddResponse(200, balanceStatementUrlsResponseJSON)
-	transport.AddResponse(200, balanceStatementUrlsResponseJSON)
-	transport.AddResponse(200, balanceStatementUrlsResponseJSON)
+	transport.AddResponse(200, statementUrlsResponseJSON)
+	transport.AddResponse(200, statementUrlsResponseJSON)
+	transport.AddResponse(200, statementUrlsResponseJSON)
 	service := New("api-key", mock)
 
 	balance, err := service.Balance.Retrieve("ba_xxx")

--- a/v1/balance_test.go
+++ b/v1/balance_test.go
@@ -2,9 +2,10 @@ package payjp
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func makeBalanceJSONStr(bank string, d string) string {
@@ -24,6 +25,13 @@ func makeBalanceJSONStr(bank string, d string) string {
 var balanceJSONStr = makeBalanceJSONStr("null", "null")
 
 var balanceResponseJSON = []byte(balanceJSONStr)
+var balanceStatementUrlsResponseJSON = []byte(`
+{
+  "expires": 1695903280,
+  "object": "statement_url",
+  "url": "url"
+}
+`)
 
 var balanceListJSONStr = `
 {
@@ -125,4 +133,42 @@ func TestBalance(t *testing.T) {
 	_, err = service.Balance.Retrieve("ba_xxx")
 	assert.IsType(t, &Error{}, err)
 	assert.Equal(t, errorStr, err.Error())
+}
+
+func TestBalanceStatementUrls(t *testing.T) {
+	mock, transport := newMockClient(200, balanceResponseJSON)
+	transport.AddResponse(400, errorResponseJSON)
+	transport.AddResponse(200, balanceStatementUrlsResponseJSON)
+	transport.AddResponse(200, balanceStatementUrlsResponseJSON)
+	transport.AddResponse(200, balanceStatementUrlsResponseJSON)
+	service := New("api-key", mock)
+
+	balance, err := service.Balance.Retrieve("ba_xxx")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/balances/ba_xxx", transport.URL)
+	assert.Equal(t, "GET", transport.Method)
+	assert.NotNil(t, balance)
+
+	_, err = service.Balance.Retrieve("ba_xxx")
+	assert.IsType(t, &Error{}, err)
+	assert.Equal(t, errorStr, err.Error())
+
+	url, err := balance.StatementUrls(StatementUrls{
+		Platformer: Bool(true),
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/balances/ba_xxx/statement_urls", transport.URL)
+	assert.Equal(t, "POST", transport.Method)
+	assert.Equal(t, "application/x-www-form-urlencoded", transport.Header.Get("Content-Type"))
+	assert.Equal(t, "platformer=true", *transport.Body)
+	assert.NotNil(t, url)
+	assert.Equal(t, "url", url.URL)
+
+	_, err = balance.StatementUrls()
+	assert.NoError(t, err)
+	assert.Equal(t, "", *transport.Body)
+
+	_, err = balance.StatementUrls(StatementUrls{})
+	assert.NoError(t, err)
+	assert.Equal(t, "", *transport.Body)
 }

--- a/v1/client.go
+++ b/v1/client.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const Version = "v0.2.1"
+const Version = "v0.2.2"
 const tagName = "form"
 const rateLimitStatusCode = 429
 


### PR DESCRIPTION
## Overview

Add statement url property to balance object.

## Changes

https://pay.jp/docs/api/#balance-%E6%AE%8B%E9%AB%98

https://pay.jp/docs/guideline-term-statement-balance#balance%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88