### PR TITLE
CardにEmailとPhoneを追加

### DIFF
--- a/v1/card.go
+++ b/v1/card.go
@@ -14,6 +14,8 @@ type Card struct {
 	AddressCity  interface{}       // 市区町村
 	AddressLine1 interface{}       // 番地など
 	AddressLine2 interface{}       // 建物名など
+	Email        interface{}       // メールアドレス
+	Phone        interface{}       // E.164形式の電話番号
 	Metadata     map[string]string // メタデータ
 }
 
@@ -40,6 +42,8 @@ type CardResponse struct {
 	Object             string            `json:"object"`
 	Metadata           map[string]string `json:"metadata"`
 	ThreeDSecureStatus *string           `json:"three_d_secure_status"`
+	Email              *string           `json:"email"`
+	Phone              *string           `json:"phone"`
 
 	customerID string
 	service    *Service

--- a/v1/card_test.go
+++ b/v1/card_test.go
@@ -25,10 +25,12 @@ var cardResponseJSONStr = `
   "id": "car_f7d9fa98594dc7c2e42bfcd641ff",
   "last4": "4242",
   "livemode": false,
-  "name": null,
+  "name": "PAY TARO",
   "three_d_secure_status": null,
   "metadata": {},
-  "object": "card"
+  "object": "card",
+  "email": "liveaccount@example.com",
+  "phone": "+81301234567"
 }`
 var cardResponseJSON = []byte(cardResponseJSONStr)
 
@@ -61,10 +63,12 @@ var cardUpdateResponseJSON = []byte(`
   "id": "car_f7d9fa98594dc7c2e42bfcd641ff",
   "last4": "4242",
   "livemode": false,
-  "name": "pay",
+  "name": "PAY TARO",
   "three_d_secure_status": "verified",
   "metadata": {},
-  "object": "card"
+  "object": "card",
+  "email": "liveaccount@example.com",
+  "phone": "+81301234567"
 }`)
 
 var deleteResponseJSONStr = `
@@ -93,6 +97,8 @@ func TestParseCardResponseJSON(t *testing.T) {
 	assert.Equal(t, map[string]string{}, card.Metadata)
 	assert.Equal(t, customerID, card.customerID)
 	assert.Equal(t, service, card.service)
+	assert.Equal(t, "liveaccount@example.com", *card.Email)
+	assert.Equal(t, "+81301234567", *card.Phone)
 }
 
 func TestCustomerAddCardToken(t *testing.T) {
@@ -220,14 +226,14 @@ func TestCustomerUpdateCard(t *testing.T) {
 	service := New("api-key", mock)
 
 	card, err := service.Customer.UpdateCard("cus_121673955bd7aa144de5a8f6c262", "car_f7d9fa98594dc7c2e42bfcd641ff", Card{
-		Name: "pay",
+		Name: "PAY TARO",
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "https://api.pay.jp/v1/customers/cus_121673955bd7aa144de5a8f6c262/cards/car_f7d9fa98594dc7c2e42bfcd641ff", transport.URL)
 	assert.Equal(t, "POST", transport.Method)
 	assert.Equal(t, "Basic YXBpLWtleTo=", transport.Header.Get("Authorization"))
 	assert.Equal(t, "application/x-www-form-urlencoded", transport.Header.Get("Content-Type"))
-	assert.Equal(t, "card[name]=pay", *transport.Body)
+	assert.Equal(t, "card[name]=PAY+TARO", *transport.Body)
 	assert.NotNil(t, card)
 	assert.Equal(t, "4242", card.Last4)
 
@@ -249,24 +255,24 @@ func TestCustomerResponseUpdateCard(t *testing.T) {
 	assert.NotNil(t, customer)
 
 	card := customer.Cards[0]
-	assert.Equal(t, "", card.Name)
+	assert.Equal(t, "PAY TARO", card.Name)
 	err = card.Update(Card{
-		Name: "pay",
+		Name: "PAY TARO",
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "https://api.pay.jp/v1/customers/cus_121673955bd7aa144de5a8f6c262/cards/car_f7d9fa98594dc7c2e42bfcd641ff", transport.URL)
 	assert.Equal(t, "POST", transport.Method)
 	assert.Equal(t, "Basic YXBpLWtleTo=", transport.Header.Get("Authorization"))
 	assert.Equal(t, "application/x-www-form-urlencoded", transport.Header.Get("Content-Type"))
-	assert.Equal(t, "card[name]=pay", *transport.Body)
-	assert.Equal(t, "pay", card.Name)
+	assert.Equal(t, "card[name]=PAY+TARO", *transport.Body)
+	assert.Equal(t, "PAY TARO", card.Name)
 
 	err = card.Update(Card{
-		Name: "pay",
+		Name: "PAY TARO",
 	})
 	assert.IsType(t, &Error{}, err)
 	assert.Equal(t, errorStr, err.Error())
-	assert.Equal(t, "pay", card.Name)
+	assert.Equal(t, "PAY TARO", card.Name)
 
 	card, err = customer.UpdateCard("car_f7d9fa98594dc7c2e42bfcd641ff", Card{
 		Name: "",
@@ -277,12 +283,12 @@ func TestCustomerResponseUpdateCard(t *testing.T) {
 	assert.Equal(t, "Basic YXBpLWtleTo=", transport.Header.Get("Authorization"))
 	assert.Equal(t, "application/x-www-form-urlencoded", transport.Header.Get("Content-Type"))
 	assert.Equal(t, "card[name]=", *transport.Body)
-	assert.Equal(t, "", card.Name)
+	assert.Equal(t, "PAY TARO", card.Name)
 
 	res, err := customer.UpdateCard("car_f7d9fa98594dc7c2e42bfcd641ff", Card{})
 	assert.IsType(t, &Error{}, err)
 	assert.Equal(t, errorStr, err.Error())
-	assert.Equal(t, "", card.Name)
+	assert.Equal(t, "PAY TARO", card.Name)
 	assert.Equal(t, "", res.Name)
 	// assert.Nil(t, res)
 }

--- a/v1/client.go
+++ b/v1/client.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const Version = "v0.2.3"
+const Version = "v0.2.4"
 const tagName = "form"
 const rateLimitStatusCode = 429
 

--- a/v1/token.go
+++ b/v1/token.go
@@ -50,6 +50,8 @@ func (t TokenService) Create(card Token) (*TokenResponse, error) {
 	qb.Add("card[address_zip]", card.AddressZip)
 	qb.Add("card[country]", card.Country)
 	qb.Add("card[name]", card.Name)
+	qb.Add("card[email]", card.Email)
+	qb.Add("card[phone]", card.Phone)
 
 	return parseToken(
 		t.service.request("POST", "/tokens", qb.Reader(), map[string]string{

--- a/v1/token_test.go
+++ b/v1/token_test.go
@@ -25,8 +25,10 @@ var tokenResponseJSON = []byte(`
     "fingerprint": "e1d8225886e3a7211127df751c86787f",
     "id": "car_e3ccd4e0959f45e7c75bacc4be90",
     "last4": "4242",
-    "name": null,
-    "object": "card"
+    "name": "PAY TARO",
+    "object": "card",
+	"email": "liveaccount@example.com",
+	"phone": "+81301234567"
   },
   "created": 1442290383,
   "id": "tok_5ca06b51685e001723a2c3b4aeb4",
@@ -42,6 +44,8 @@ func TestParseTokenResponseJSON(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, "tok_5ca06b51685e001723a2c3b4aeb4", token.ID)
+	assert.Equal(t, "liveaccount@example.com", *token.Card.Email)
+	assert.Equal(t, "+81301234567", *token.Card.Phone)
 }
 
 func TestTokenCreate(t *testing.T) {

--- a/v1/token_test.go
+++ b/v1/token_test.go
@@ -27,8 +27,8 @@ var tokenResponseJSON = []byte(`
     "last4": "4242",
     "name": "PAY TARO",
     "object": "card",
-	"email": "liveaccount@example.com",
-	"phone": "+81301234567"
+    "email": "liveaccount@example.com",
+    "phone": "+81301234567"
   },
   "created": 1442290383,
   "id": "tok_5ca06b51685e001723a2c3b4aeb4",


### PR DESCRIPTION
- https://help.pay.jp/ja/articles/9556161 対応
- 3Dセキュアへの連携項目としてcardオブジェクトにemailとphoneが追加されたのでその対応
- version0.2.4