### PR TITLE
feat: add token tds_finish.

### DIFF
--- a/v1/charge.go
+++ b/v1/charge.go
@@ -308,7 +308,7 @@ func (c *ChargeResponse) Capture(amount ...int) error {
 	return err
 }
 
-// TdsFinish をChrgeResponseから実行します。
+// TdsFinish を ChargeResponse から実行します。
 func (c *ChargeResponse) TdsFinish() error {
 	return c.updateResponse(c.service.Charge.TdsFinish(c.ID))
 }
@@ -346,7 +346,7 @@ type ChargeResponse struct {
 	Metadata           map[string]string `json:"metadata"`
 	FeeRate            string            `json:"fee_rate"`              // 決済手数料率
 	ThreeDSecureStatus *string           `json:"three_d_secure_status"` // 3Dセキュアの実施状況
-	TermID             string            `json:"term_id"` // TermオブジェクトID
+	TermID             string            `json:"term_id"`               // TermオブジェクトID
 	Object             string            `json:"object"`
 
 	service *Service

--- a/v1/token.go
+++ b/v1/token.go
@@ -69,6 +69,13 @@ func (t TokenService) Retrieve(id string) (*TokenResponse, error) {
 	return parseToken(t.service, body, err)
 }
 
+// TdsFinish は3Dセキュア認証が終了した支払いに対し、決済を行います。
+// https://pay.jp/docs/api/#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B
+func (t TokenService) TdsFinish(id string) (*TokenResponse, error) {
+	body, err := t.service.request("POST", "/tokens/"+id+"/tds_finish", nil)
+	return parseToken(t.service, body, err)
+}
+
 // TokenResponse はToken.Create(), Token.Retrieve()が返す構造体です。
 type TokenResponse struct {
 	CreatedAt time.Time       // このトークン作成時間
@@ -110,11 +117,4 @@ func (t *TokenResponse) updateResponse(r *TokenResponse, err error) error {
 	}
 	*t = *r
 	return nil
-}
-
-// TdsFinish は3Dセキュア認証が終了した支払いに対し、決済を行います。
-// https://pay.jp/docs/api/#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B
-func (t TokenService) TdsFinish(id string) (*TokenResponse, error) {
-	body, err := t.service.request("POST", "/tokens/"+id+"/tds_finish", nil)
-	return parseToken(t.service, body, err)
 }

--- a/v1/token.go
+++ b/v1/token.go
@@ -12,10 +12,11 @@ type TokenService struct {
 
 type Token struct {
 	Card
-	Number   interface{} // カード番号
-	ExpMonth interface{} // 有効期限月
-	ExpYear  interface{} // 有効期限年
-	CVC      interface{} // CVCコード
+	Number       interface{} // カード番号
+	ExpMonth     interface{} // 有効期限月
+	ExpYear      interface{} // 有効期限年
+	CVC          interface{} // CVCコード
+	ThreeDSecure *bool       // 3DSecureを実施するか否か
 }
 
 func newTokenService(service *Service) *TokenService {
@@ -24,7 +25,7 @@ func newTokenService(service *Service) *TokenService {
 	}
 }
 
-func parseToken(data []byte, err error) (*TokenResponse, error) {
+func parseToken(service *Service, data []byte, err error) (*TokenResponse, error) {
 	if err != nil {
 		return nil, err
 	}
@@ -33,6 +34,7 @@ func parseToken(data []byte, err error) (*TokenResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	result.service = service
 	return result, err
 }
 
@@ -52,16 +54,19 @@ func (t TokenService) Create(card Token) (*TokenResponse, error) {
 	qb.Add("card[name]", card.Name)
 	qb.Add("card[email]", card.Email)
 	qb.Add("card[phone]", card.Phone)
+	qb.Add("three_d_secure", card.ThreeDSecure)
 
-	return parseToken(
-		t.service.request("POST", "/tokens", qb.Reader(), map[string]string{
-			"X-Payjp-Direct-Token-Generate": "true",
-		}))
+	body, err := t.service.request("POST", "/tokens", qb.Reader(), map[string]string{
+		"X-Payjp-Direct-Token-Generate": "true",
+	})
+
+	return parseToken(t.service, body, err)
 }
 
 // Retrieve token object. 特定のトークン情報を取得します。
 func (t TokenService) Retrieve(id string) (*TokenResponse, error) {
-	return parseToken(t.service.request("GET", "/tokens/"+id, nil))
+	body, err := t.service.request("GET", "/tokens/"+id, nil)
+	return parseToken(t.service, body, err)
 }
 
 // TokenResponse はToken.Create(), Token.Retrieve()が返す構造体です。
@@ -92,4 +97,24 @@ func (t *TokenResponse) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 	return parseError(b)
+}
+
+// TdsFinish を TokenResponse から実行します。
+func (t *TokenResponse) TdsFinish() error {
+	return t.updateResponse(t.service.Token.TdsFinish(t.ID))
+}
+
+func (t *TokenResponse) updateResponse(r *TokenResponse, err error) error {
+	if err != nil {
+		return err
+	}
+	*t = *r
+	return nil
+}
+
+// TdsFinish は3Dセキュア認証が終了した支払いに対し、決済を行います。
+// https://pay.jp/docs/api/#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B
+func (t TokenService) TdsFinish(id string) (*TokenResponse, error) {
+	body, err := t.service.request("POST", "/tokens/"+id+"/tds_finish", nil)
+	return parseToken(t.service, body, err)
 }

--- a/v1/token_test.go
+++ b/v1/token_test.go
@@ -63,7 +63,7 @@ var tokenNewResponseJSON = []byte(`
     "object": "card",
     "email": "liveaccount@example.com",
     "phone": "+81301234567",
-	"three_d_secure_status": "verified"
+    "three_d_secure_status": "verified"
   },
   "created": 1442290383,
   "id": "tok_5ca06b51685e001723a2c3b4aeb4",

--- a/v1/token_test.go
+++ b/v1/token_test.go
@@ -2,8 +2,9 @@ package payjp
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var tokenResponseJSON = []byte(`
@@ -29,6 +30,40 @@ var tokenResponseJSON = []byte(`
     "object": "card",
     "email": "liveaccount@example.com",
     "phone": "+81301234567"
+  },
+  "created": 1442290383,
+  "id": "tok_5ca06b51685e001723a2c3b4aeb4",
+  "livemode": false,
+  "object": "token",
+  "used": false
+}
+`)
+
+// changes: three_d_secure_status
+var tokenNewResponseJSON = []byte(`
+{
+  "card": {
+    "address_city": null,
+    "address_line1": null,
+    "address_line2": null,
+    "address_state": null,
+    "address_zip": null,
+    "address_zip_check": "unchecked",
+    "brand": "Visa",
+    "country": null,
+    "created": 1442290383,
+    "customer": null,
+    "cvc_check": "passed",
+    "exp_month": 2,
+    "exp_year": 2020,
+    "fingerprint": "e1d8225886e3a7211127df751c86787f",
+    "id": "car_e3ccd4e0959f45e7c75bacc4be90",
+    "last4": "4242",
+    "name": "PAY TARO",
+    "object": "card",
+    "email": "liveaccount@example.com",
+    "phone": "+81301234567",
+	"three_d_secure_status": "verified"
   },
   "created": 1442290383,
   "id": "tok_5ca06b51685e001723a2c3b4aeb4",
@@ -90,4 +125,40 @@ func TestTokenRetrieve(t *testing.T) {
 	token, err = service.Token.Retrieve("hoge")
 	assert.Nil(t, token)
 	assert.Error(t, err)
+}
+
+func TestTokenTdsFinish(t *testing.T) {
+	mock, transport := newMockClient(200, tokenResponseJSON)
+	transport.AddResponse(400, errorResponseJSON)
+	transport.AddResponse(200, tokenNewResponseJSON)
+	transport.AddResponse(400, errorResponseJSON)
+	service := New("api-key", mock)
+
+	token, err := service.Token.TdsFinish("tok_req")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/tokens/tok_req/tds_finish", transport.URL)
+	assert.Equal(t, "POST", transport.Method)
+	assert.Equal(t, "Basic YXBpLWtleTo=", transport.Header.Get("Authorization"))
+	assert.Equal(t, "", transport.Header.Get("Content-Type"))
+	assert.Nil(t, transport.Body)
+
+	tokenErr, err := service.Token.TdsFinish("tok_req")
+	assert.Error(t, err)
+	payErr := err.(*Error)
+	assert.Equal(t, 400, payErr.Status)
+	assert.Nil(t, tokenErr)
+
+	err = token.TdsFinish()
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/tokens/tok_5ca06b51685e001723a2c3b4aeb4/tds_finish", transport.URL)
+	assert.Equal(t, "POST", transport.Method)
+	assert.Equal(t, "Basic YXBpLWtleTo=", transport.Header.Get("Authorization"))
+	assert.Equal(t, "", transport.Header.Get("Content-Type"))
+	assert.Nil(t, transport.Body)
+	assert.Equal(t, "verified", *token.Card.ThreeDSecureStatus)
+
+	err = token.TdsFinish()
+	assert.IsType(t, &Error{}, err)
+	assert.Equal(t, errorStr, err.Error())
+	assert.NotNil(t, token)
 }


### PR DESCRIPTION
## Overview

add token tds_finish.

* [トークンに対する3Dセキュアフローを完了する – PAY.JP API リファレンス](https://pay.jp/docs/api/#%E3%83%88%E3%83%BC%E3%82%AF%E3%83%B3%E3%81%AB%E5%AF%BE%E3%81%99%E3%82%8B3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%95%E3%83%AD%E3%83%BC%E3%82%92%E5%AE%8C%E4%BA%86%E3%81%99%E3%82%8B)
