### PR TITLE
feat: add endpoints about ThreeDSecureRequest object.

### DIFF
--- a/v1/client.go
+++ b/v1/client.go
@@ -89,17 +89,18 @@ type Service struct {
 	MaxDelay     float64
 	Logger       LoggerInterface
 
-	Charge       *ChargeService
-	Customer     *CustomerService
-	Plan         *PlanService
-	Subscription *SubscriptionService
-	Token        *TokenService
-	Transfer     *TransferService
-	Statement    *StatementService
-	Term         *TermService
-	Balance      *BalanceService
-	Event        *EventService
-	Account      *AccountService
+	Charge              *ChargeService
+	Customer            *CustomerService
+	Plan                *PlanService
+	Subscription        *SubscriptionService
+	Token               *TokenService
+	Transfer            *TransferService
+	Statement           *StatementService
+	Term                *TermService
+	Balance             *BalanceService
+	Event               *EventService
+	Account             *AccountService
+	ThreeDSecureRequest *ThreeDSecureRequestService
 }
 
 // New はPAY.JPのAPIを初期化する関数です。
@@ -138,6 +139,7 @@ func New(apiKey string, client *http.Client, configs ...ServiceConfig) *Service 
 	service.Balance = newBalanceService(service)
 	service.Term = newTermService(service)
 	service.Event = newEventService(service)
+	service.ThreeDSecureRequest = newThreeDSecureRequestService(service)
 
 	return service
 }

--- a/v1/client.go
+++ b/v1/client.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-const Version = "v0.2.4"
+const Version = "v0.3.0"
 const tagName = "form"
 const rateLimitStatusCode = 429
 

--- a/v1/three_d_secure_request.go
+++ b/v1/three_d_secure_request.go
@@ -1,0 +1,117 @@
+package payjp
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type ThreeDSecureRequestService struct {
+	service *Service
+}
+
+func newThreeDSecureRequestService(service *Service) *ThreeDSecureRequestService {
+	return &ThreeDSecureRequestService{
+		service: service,
+	}
+}
+
+// ThreeDSecureRequest は3Dセキュアリクエストの作成時に使用する構造体です。
+type ThreeDSecureRequest struct {
+	ResourceID string // 必須: 顧客カードID。
+	TenantID   string // テナントID
+}
+
+func (t ThreeDSecureRequestService) Create(threeDSecureRequest ThreeDSecureRequest) (*ThreeDSecureRequestResponse, error) {
+	qb := newRequestBuilder()
+	qb.Add("resource_id", threeDSecureRequest.ResourceID)
+	if threeDSecureRequest.TenantID != "" {
+		qb.Add("tenant_id", threeDSecureRequest.TenantID)
+	}
+
+	body, err := t.service.request("POST", "/three_d_secure_requests", qb.Reader())
+	if err != nil {
+		return nil, err
+	}
+	return parseThreeDSecureRequest(t.service, body, &ThreeDSecureRequestResponse{})
+}
+
+func parseThreeDSecureRequest(service *Service, body []byte, result *ThreeDSecureRequestResponse) (*ThreeDSecureRequestResponse, error) {
+	err := json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	result.service = service
+	return result, nil
+}
+
+func (s ThreeDSecureRequestService) Retrieve(id string) (*ThreeDSecureRequestResponse, error) {
+	body, err := s.service.request("GET", "/three_d_secure_requests/"+id, nil)
+	if err != nil {
+		return nil, err
+	}
+	result := &ThreeDSecureRequestResponse{}
+	err = json.Unmarshal(body, result)
+	if err != nil {
+		return nil, err
+	}
+	result.service = s.service
+	return result, nil
+}
+
+type ThreeDSecureRequestResponse struct {
+	ID                 string `json:"id"`
+	ResourceID         string `json:"resource_id"`
+	Object             string `json:"object"`
+	LiveMode           bool   `json:"livemode"`
+	Created            *int   `json:"created"`
+	CreatedAt          time.Time
+	State              string  `form:"state"`
+	StartedAt          *int    `json:"started_at"`
+	ResultReceivedAt   *int    `json:"result_received_at"`
+	FinishedAt         *int    `json:"finished_at"`
+	ExpiredAt          *int    `json:"expired_at"`
+	TenantId           *string `json:"tenant_id"`
+	ThreeDSecureStatus string  `json:"three_d_secure_status"`
+	service            *Service
+}
+
+func (s *ThreeDSecureRequestResponse) UnmarshalJSON(b []byte) error {
+	type threeDSecureRequestResponseParser ThreeDSecureRequestResponse
+	var raw threeDSecureRequestResponseParser
+	err := json.Unmarshal(b, &raw)
+	if err == nil && raw.Object == "three_d_secure_request" {
+		raw.CreatedAt = time.Unix(IntValue(raw.Created), 0)
+		raw.service = s.service
+		*s = ThreeDSecureRequestResponse(raw)
+		return nil
+	}
+	return parseError(b)
+}
+
+type ThreeDSecureRequestListParams struct {
+	ListParams `form:"*"`
+	ResourceID *string `form:"resource_id"`
+	TenantID   *string `form:"tenant_id"`
+}
+
+func (c ThreeDSecureRequestService) All(params ...*ThreeDSecureRequestListParams) ([]*ThreeDSecureRequestResponse, bool, error) {
+	p := &ThreeDSecureRequestListParams{}
+	if len(params) > 0 {
+		p = params[0]
+	}
+	body, err := c.service.request("GET", "/three_d_secure_requests"+c.service.getQuery(p), nil)
+	if err != nil {
+		return nil, false, err
+	}
+	raw := &listResponseParser{}
+	err = json.Unmarshal(body, raw)
+	if err != nil {
+		return nil, false, err
+	}
+	result := make([]*ThreeDSecureRequestResponse, len(raw.Data))
+	for i, rawS := range raw.Data {
+		json.Unmarshal(rawS, &result[i])
+		result[i].service = c.service
+	}
+	return result, raw.HasMore, nil
+}

--- a/v1/three_d_secure_request.go
+++ b/v1/three_d_secure_request.go
@@ -17,16 +17,14 @@ func newThreeDSecureRequestService(service *Service) *ThreeDSecureRequestService
 
 // ThreeDSecureRequest は3Dセキュアリクエストの作成時に使用する構造体です。
 type ThreeDSecureRequest struct {
-	ResourceID string // 必須: 顧客カードID。
-	TenantID   string // テナントID
+	ResourceID string  // 必須: 顧客カードID。
+	TenantID   *string // テナントID
 }
 
 func (t ThreeDSecureRequestService) Create(threeDSecureRequest ThreeDSecureRequest) (*ThreeDSecureRequestResponse, error) {
 	qb := newRequestBuilder()
 	qb.Add("resource_id", threeDSecureRequest.ResourceID)
-	if threeDSecureRequest.TenantID != "" {
-		qb.Add("tenant_id", threeDSecureRequest.TenantID)
-	}
+	qb.Add("tenant_id", threeDSecureRequest.TenantID)
 
 	body, err := t.service.request("POST", "/three_d_secure_requests", qb.Reader())
 	if err != nil {

--- a/v1/three_d_secure_request_test.go
+++ b/v1/three_d_secure_request_test.go
@@ -124,7 +124,7 @@ func TestThreeDSecureRequestCreate(t *testing.T) {
 
 	threeDSecureRequest, err = service.ThreeDSecureRequest.Create(ThreeDSecureRequest{
 		ResourceID: "car_4ec110e0700daf893160424fe03c",
-		TenantID:   "ten_xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+		TenantID:   String("ten_xxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
 	})
 	assert.NoError(t, err)
 	assert.Equal(t, "resource_id=car_4ec110e0700daf893160424fe03c&tenant_id=ten_xxxxxxxxxxxxxxxxxxxxxxxxxxxx", *transport.Body)

--- a/v1/three_d_secure_request_test.go
+++ b/v1/three_d_secure_request_test.go
@@ -1,0 +1,139 @@
+package payjp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var threeDSecureRequestJSONStr = `{
+  "created": 1730084767,
+  "expired_at": null,
+  "finished_at": null,
+  "id": "tdsr_125192559c91c4011c1ff56f50a",
+  "livemode": true,
+  "object": "three_d_secure_request",
+  "resource_id": "car_4ec110e0700daf893160424fe03c",
+  "result_received_at": null,
+  "started_at": null,
+  "state": "created",
+  "tenant_id": null,
+  "three_d_secure_status": "unverified"
+}`
+
+var threeDSecureRequestResponseJSON = []byte(threeDSecureRequestJSONStr)
+
+var threeDSecureRequestsListJSONStr = `
+{
+  "count": 1,
+  "data": [` + threeDSecureRequestJSONStr +
+	`],
+  "has_more": false,
+  "object": "list",
+  "url": "/v1/three_d_secure_requests"
+}`
+var threeDSecureRequestsListResponseJSON = []byte(threeDSecureRequestsListJSONStr)
+
+func TestParseThreeDSecureRequest(t *testing.T) {
+	service := &Service{}
+	s := &ThreeDSecureRequestResponse{
+		service: service,
+	}
+	err := json.Unmarshal(threeDSecureRequestResponseJSON, s)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "tdsr_125192559c91c4011c1ff56f50a", s.ID)
+	assert.True(t, s.LiveMode)
+	assert.Equal(t, "three_d_secure_request", s.Object)
+	assert.Equal(t, "car_4ec110e0700daf893160424fe03c", s.ResourceID)
+	assert.Nil(t, s.StartedAt)
+	assert.Nil(t, s.ResultReceivedAt)
+	assert.Nil(t, s.FinishedAt)
+	assert.Nil(t, s.ExpiredAt)
+	assert.Nil(t, s.TenantId)
+	assert.Equal(t, "unverified", s.ThreeDSecureStatus)
+	assert.Equal(t, service, s.service)
+}
+
+func TestThreeDSecureRequestList(t *testing.T) {
+	mock, transport := newMockClient(200, threeDSecureRequestsListResponseJSON)
+	transport.AddResponse(400, errorResponseJSON)
+	service := New("api-key", mock)
+
+	limit := Int(10)
+	offset := Int(0)
+	params := &ThreeDSecureRequestListParams{
+		ListParams: ListParams{
+			Limit:  limit,
+			Offset: offset,
+			Since:  Int(1455328095),
+			Until:  Int(1455328095),
+		},
+	}
+	res, hasMore, err := service.ThreeDSecureRequest.All(params)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/three_d_secure_requests?limit=10&offset=0&since=1455328095&until=1455328095", transport.URL)
+	assert.Equal(t, "GET", transport.Method)
+	assert.False(t, hasMore)
+	assert.Equal(t, len(res), 1)
+	assert.Equal(t, "tdsr_125192559c91c4011c1ff56f50a", res[0].ID)
+	assert.Equal(t, service, res[0].service)
+
+	_, hasMore, err = service.ThreeDSecureRequest.All()
+	assert.False(t, hasMore)
+	assert.IsType(t, &Error{}, err)
+	assert.Equal(t, errorStr, err.Error())
+}
+
+func TestThreeDSecureRequest(t *testing.T) {
+	mock, transport := newMockClient(200, threeDSecureRequestResponseJSON)
+	transport.AddResponse(400, errorResponseJSON)
+	service := New("api-key", mock)
+
+	v, err := service.ThreeDSecureRequest.Retrieve("tdsr_125192559c91c4011c1ff56f50a")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/three_d_secure_requests/tdsr_125192559c91c4011c1ff56f50a", transport.URL)
+	assert.Equal(t, "GET", transport.Method)
+	assert.NotNil(t, v)
+	assert.Equal(t, "tdsr_125192559c91c4011c1ff56f50a", v.ID)
+
+	_, err = service.ThreeDSecureRequest.Retrieve("tdsr_125192559c91c4011c1ff56f50a")
+	assert.IsType(t, &Error{}, err)
+	assert.Equal(t, errorStr, err.Error())
+}
+
+func TestThreeDSecureRequestCreate(t *testing.T) {
+	mock, transport := newMockClient(200, threeDSecureRequestResponseJSON)
+	transport.AddResponse(200, threeDSecureRequestResponseJSON)
+	transport.AddResponse(400, errorResponseJSON)
+	service := New("api-key", mock)
+
+	threeDSecureRequest, err := service.ThreeDSecureRequest.Create(ThreeDSecureRequest{
+		ResourceID: "car_4ec110e0700daf893160424fe03c",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://api.pay.jp/v1/three_d_secure_requests", transport.URL)
+	assert.Equal(t, "POST", transport.Method)
+	assert.Equal(t, "Basic YXBpLWtleTo=", transport.Header.Get("Authorization"))
+	assert.Equal(t, "application/x-www-form-urlencoded", transport.Header.Get("Content-Type"))
+	assert.Equal(t, "resource_id=car_4ec110e0700daf893160424fe03c", *transport.Body)
+	assert.NotNil(t, threeDSecureRequest)
+	assert.Equal(t, "tdsr_125192559c91c4011c1ff56f50a", threeDSecureRequest.ID)
+	assert.Equal(t, "car_4ec110e0700daf893160424fe03c", threeDSecureRequest.ResourceID)
+
+	threeDSecureRequest, err = service.ThreeDSecureRequest.Create(ThreeDSecureRequest{
+		ResourceID: "car_4ec110e0700daf893160424fe03c",
+		TenantID:   "ten_xxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, "resource_id=car_4ec110e0700daf893160424fe03c&tenant_id=ten_xxxxxxxxxxxxxxxxxxxxxxxxxxxx", *transport.Body)
+	assert.NotNil(t, threeDSecureRequest)
+
+	_, err = service.ThreeDSecureRequest.Create(ThreeDSecureRequest{
+		ResourceID: "car_4ec110e0700daf893160424fe03c",
+	})
+	assert.Equal(t, "resource_id=car_4ec110e0700daf893160424fe03c", *transport.Body)
+	assert.IsType(t, &Error{}, err)
+	assert.Equal(t, errorStr, err.Error())
+}


### PR DESCRIPTION
## Overview

add endpoints about ThreeDSecureRequest object.

* [3Dセキュアリクエストを作成 – PAY.JP API リファレンス](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%82%92%E4%BD%9C%E6%88%90)
* [3Dセキュアリクエスト情報を取得 – PAY.JP API リファレンス](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E6%83%85%E5%A0%B1%E3%82%92%E5%8F%96%E5%BE%97)
* [3Dセキュアリクエストリストを取得 – PAY.JP API リファレンス](https://pay.jp/docs/api/#3d%E3%82%BB%E3%82%AD%E3%83%A5%E3%82%A2%E3%83%AA%E3%82%AF%E3%82%A8%E3%82%B9%E3%83%88%E3%83%AA%E3%82%B9%E3%83%88%E3%82%92%E5%8F%96%E5%BE%97)

